### PR TITLE
Fix syntax error in register route

### DIFF
--- a/mainproject/backend/routes/register.js
+++ b/mainproject/backend/routes/register.js
@@ -24,7 +24,7 @@ router.post("/", async (req, res) => {
     const existing = await prisma.user.findUnique({ where: { email } });
     if (existing) {
       return res.status(409).json({ error: "User already exists" });
-``  }
+    }
 
 
     res.json({ status: "ok", user: newUser });


### PR DESCRIPTION
## Summary
- fix stray backticks in `register.js`

## Testing
- `npm test` *(fails: no tests defined)*

------
https://chatgpt.com/codex/tasks/task_e_6852e0d23670832cb7772ab25ebaff28